### PR TITLE
[n/a] rollback to previous version to be compatible with oauth-client 2.4.1

### DIFF
--- a/src/Provider/Spotify.php
+++ b/src/Provider/Spotify.php
@@ -8,7 +8,7 @@ use Kerox\OAuth2\Client\Provider\Exception\SpotifyIdentityProviderException;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
-use League\OAuth2\Client\Token\AccessTokenInterface;
+use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use Psr\Http\Message\ResponseInterface;
 
@@ -79,11 +79,11 @@ class Spotify extends AbstractProvider
     /**
      * Returns the URL for requesting the resource owner's details.
      *
-     * @param AccessTokenInterface $token
+     * @param AccessToken $token
      *
      * @return string
      */
-    public function getResourceOwnerDetailsUrl(AccessTokenInterface $token): string
+    public function getResourceOwnerDetailsUrl(AccessToken $token): string
     {
         return 'https://api.spotify.com/v1/me';
     }
@@ -105,7 +105,7 @@ class Spotify extends AbstractProvider
      * Checks a provider response for errors.
      *
      * @param ResponseInterface $response
-     * @param array|string      $data     Parsed response data
+     * @param array|string      $data Parsed response data
      *
      * @throws IdentityProviderException
      */
@@ -128,12 +128,12 @@ class Spotify extends AbstractProvider
      * Generates a resource owner object from a successful resource owner
      * details request.
      *
-     * @param array                $response
-     * @param AccessTokenInterface $token
+     * @param array       $response
+     * @param AccessToken $token
      *
      * @return ResourceOwnerInterface
      */
-    protected function createResourceOwner(array $response, AccessTokenInterface $token): ResourceOwnerInterface
+    protected function createResourceOwner(array $response, AccessToken $token): ResourceOwnerInterface
     {
         return new SpotifyResourceOwner($response);
     }

--- a/src/Provider/Spotify.php
+++ b/src/Provider/Spotify.php
@@ -105,7 +105,7 @@ class Spotify extends AbstractProvider
      * Checks a provider response for errors.
      *
      * @param ResponseInterface $response
-     * @param array|string      $data Parsed response data
+     * @param array|string      $data     Parsed response data
      *
      * @throws IdentityProviderException
      */

--- a/tests/TestCase/Provider/SpotifyTest.php
+++ b/tests/TestCase/Provider/SpotifyTest.php
@@ -2,16 +2,16 @@
 
 namespace Kerox\OAuth2\Client\Test\TestCase\Provider;
 
+use GuzzleHttp\ClientInterface;
 use Kerox\OAuth2\Client\Provider\Exception\SpotifyIdentityProviderException;
 use Kerox\OAuth2\Client\Provider\Spotify;
-use League\OAuth2\Client\Token\AccessTokenInterface;
+use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\ClientInterface;
 
 class FooSpotifyProvider extends Spotify
 {
-    protected function fetchResourceOwnerDetails(AccessTokenInterface $token)
+    protected function fetchResourceOwnerDetails(AccessToken $token)
     {
         return json_decode(file_get_contents(__DIR__ . '/../../Mocks/user.json'), true);
     }
@@ -69,7 +69,7 @@ class SpotifyTest extends TestCase
 
     public function testGetResourceOwnerDetailsUrl(): void
     {
-        $accessToken = $this->createMock(AccessTokenInterface::class);
+        $accessToken = $this->createMock(AccessToken::class);
 
         $url = $this->provider->getResourceOwnerDetailsUrl($accessToken);
         $uri = parse_url($url);
@@ -102,7 +102,7 @@ class SpotifyTest extends TestCase
     {
         $provider = new FooSpotifyProvider();
 
-        $token = $this->createMock(AccessTokenInterface::class);
+        $token = $this->createMock(AccessToken::class);
         $user = $provider->getResourceOwner($token);
 
         $this->assertEquals('1990-01-01', $user->getBirthDate($token));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT

Rollback to previous version to fix errors raised by league/oauth2-client 2.4.1
